### PR TITLE
Conditionally draw separator in conversation list

### DIFF
--- a/Sources/UI/application/DJLAppDelegate.h
+++ b/Sources/UI/application/DJLAppDelegate.h
@@ -28,4 +28,6 @@
 
 - (void) addAccount;
 
+- (void) toggleEnableVibrancy;
+
 @end

--- a/Sources/UI/application/DJLAppDelegate.mm
+++ b/Sources/UI/application/DJLAppDelegate.mm
@@ -84,6 +84,11 @@ private:
     MC_SAFE_RELEASE(_callback);
 }
 
+- (void) toggleEnableVibrancy
+{
+    [_mainWindowController toggleEnableVibrancy];
+}
+
 - (void) _receiveWakeNote
 {
     [[SUUpdater sharedUpdater] checkForUpdatesInBackground];

--- a/Sources/UI/conversationlist/DJLConversationCellContentView.h
+++ b/Sources/UI/conversationlist/DJLConversationCellContentView.h
@@ -10,6 +10,7 @@
 @property (nonatomic, weak) id <DJLConversationCellViewDelegate> delegate;
 @property (nonatomic, retain) NSDictionary * conversation;
 @property (nonatomic, assign, getter=isSelected) BOOL selected;
+@property (nonatomic, assign, getter=isNextCellSelected) BOOL nextCellSelected;
 @property (nonatomic, assign) CGFloat vibrancy;
 @property (nonatomic, retain) NSString * folderPath;
 

--- a/Sources/UI/conversationlist/DJLConversationCellContentView.m
+++ b/Sources/UI/conversationlist/DJLConversationCellContentView.m
@@ -30,9 +30,10 @@
     [_effectView addSubview:_opaqueView];
     [_effectView addSubview:_mainView];
     [self addSubview:_effectView];
-    _vibrancy = 1.0;
-    [_mainView setVibrancy:1.0];
-    [_opaqueView setAlphaValue:0.0];
+    BOOL enableVibrancy = [[NSUserDefaults standardUserDefaults] boolForKey:@"DJLEnableVibrancy"];
+    _vibrancy = enableVibrancy ? 1.0 : 0.0;
+    [_mainView setVibrancy:enableVibrancy ? 1.0 : 0.0];
+    [_opaqueView setAlphaValue:enableVibrancy ? 0.0 : 1.0];
     return self;
 }
 
@@ -102,6 +103,9 @@
 
 - (void) setVibrancy:(CGFloat)vibrancy
 {
+    BOOL enableVibrancy = [[NSUserDefaults standardUserDefaults] boolForKey:@"DJLEnableVibrancy"];
+    vibrancy = enableVibrancy ? vibrancy : 0.0;
+    
     if (_vibrancy == vibrancy) {
         return;
     }
@@ -115,13 +119,11 @@
         [_mainView setVibrancy:_vibrancy];
         [_opaqueView setAlphaValue:1.0];
         [_effectView setMaterial:NSVisualEffectMaterialTitlebar];
-        [_opaqueView setBackgroundColor:[NSColor colorWithCalibratedWhite:0.9 alpha:1.0]];
     }
     else {
         [_mainView setVibrancy:_vibrancy];
         [_opaqueView setAlphaValue:1.0 - _vibrancy];
         [_effectView setMaterial:NSVisualEffectMaterialLight];
-        [_opaqueView setBackgroundColor:[NSColor whiteColor]];
     }
     [self update];
 }

--- a/Sources/UI/conversationlist/DJLConversationCellContentView.m
+++ b/Sources/UI/conversationlist/DJLConversationCellContentView.m
@@ -11,6 +11,7 @@
     NSVisualEffectView * _effectView;
     DJLColoredView * _opaqueView;
     BOOL _selected;
+    BOOL _nextCellSelected;
     CGFloat _vibrancy;
     NSString * _folderPath;
 }
@@ -78,6 +79,20 @@
 - (BOOL) isSelected
 {
     return _selected;
+}
+
+- (void) setNextCellSelected:(BOOL)nextCellSelected
+{
+    if (_nextCellSelected == nextCellSelected) {
+        return;
+    }
+    _nextCellSelected = nextCellSelected;
+    [_mainView setNextCellSelected:_nextCellSelected];
+}
+
+- (BOOL) isNextCellSelected
+{
+    return _nextCellSelected;
 }
 
 - (CGFloat) vibrancy

--- a/Sources/UI/conversationlist/DJLConversationCellView.h
+++ b/Sources/UI/conversationlist/DJLConversationCellView.h
@@ -12,6 +12,7 @@
 @property (nonatomic, weak) id <DJLConversationCellViewDelegate> delegate;
 @property (nonatomic, retain) NSDictionary * conversation;
 @property (nonatomic, assign, getter=isSelected) BOOL selected;
+@property (nonatomic, assign, getter=isNextCellSelected) BOOL nextCellSelected;
 @property (nonatomic, assign) CGFloat vibrancy;
 @property (nonatomic, retain) NSString * folderPath;
 

--- a/Sources/UI/conversationlist/DJLConversationCellView.mm
+++ b/Sources/UI/conversationlist/DJLConversationCellView.mm
@@ -556,7 +556,7 @@ using namespace mailcore;
             NSString * senderFirstLetter = [[senders substringToIndex:1] uppercaseString];
             NSDictionary * avatarAttr = @{NSFontAttributeName: avatarFont, NSForegroundColorAttributeName: [NSColor colorWithWhite:0.4 alpha:1.0]};
             NSSize size = [senderFirstLetter sizeWithAttributes:avatarAttr];
-            NSPoint position = NSMakePoint((avatarSize - size.width) / 2, (avatarSize - size.height) / 2);
+            NSPoint position = NSMakePoint((avatarSize - size.width) / 2, (avatarSize - size.height) / 2 + 0.5);
             [senderFirstLetter drawAtPoint:NSMakePoint(8 + statusMargin + position.x, (int) ((bounds.size.height - avatarSize) / 2) + position.y) withAttributes:avatarAttr];
         }
     }

--- a/Sources/UI/conversationlist/DJLConversationCellView.mm
+++ b/Sources/UI/conversationlist/DJLConversationCellView.mm
@@ -233,6 +233,7 @@ using namespace mailcore;
     __weak id <DJLConversationCellViewDelegate> _delegate;
     FBKVOController * _kvoController;
     BOOL _selected;
+    BOOL _nextCellSelected;
     CGFloat _vibrancy;
 }
 
@@ -573,11 +574,14 @@ using namespace mailcore;
         [str drawAtPoint:NSMakePoint(0, bounds.size.height - 30) withAttributes:attr];
     }
 
-    path = [[NSBezierPath alloc] init];
-    [path moveToPoint:NSMakePoint(60, 0)];
-    [path lineToPoint:NSMakePoint(bounds.size.width, 0)];
-    [[NSColor colorWithCalibratedWhite:0.0 alpha:0.15] setStroke];
-    [path stroke];
+    // Separator line. Do not draw it above or below selection highlight.
+    if (!_nextCellSelected && !_selected) {
+        path = [[NSBezierPath alloc] init];
+        [path moveToPoint:NSMakePoint(60, 0)];
+        [path lineToPoint:NSMakePoint(bounds.size.width, 0)];
+        [[NSColor colorWithCalibratedWhite:0.0 alpha:0.15] setStroke];
+        [path stroke];
+    }
 }
 
 - (void) setConversation:(NSDictionary *)conversation
@@ -617,6 +621,20 @@ using namespace mailcore;
     }
     _selected = selected;
     [_snippetView setSelected:_selected];
+    [self setNeedsDisplay:YES];
+}
+
+- (BOOL) isNextCellSelected
+{
+    return _nextCellSelected;
+}
+
+- (void) setNextCellSelected:(BOOL)nextCellSelected
+{
+    if (_nextCellSelected == nextCellSelected) {
+        return;
+    }
+    _nextCellSelected = nextCellSelected;
     [self setNeedsDisplay:YES];
 }
 

--- a/Sources/UI/conversationlist/DJLConversationCellView.mm
+++ b/Sources/UI/conversationlist/DJLConversationCellView.mm
@@ -37,6 +37,9 @@ using namespace mailcore;
 
 - (void) setVibrancy:(CGFloat)vibrancy
 {
+    BOOL enableVibrancy = [[NSUserDefaults standardUserDefaults] boolForKey:@"DJLEnableVibrancy"];
+    vibrancy = enableVibrancy ? vibrancy : 0.0;
+    
     _vibrancy = vibrancy;
     [self setNeedsDisplay:YES];
 }
@@ -640,6 +643,9 @@ using namespace mailcore;
 
 - (void) setVibrancy:(CGFloat)vibrancy
 {
+    BOOL enableVibrancy = [[NSUserDefaults standardUserDefaults] boolForKey:@"DJLEnableVibrancy"];
+    vibrancy = enableVibrancy ? vibrancy : 0.0;
+    
     if (_vibrancy == vibrancy) {
         return;
     }

--- a/Sources/UI/conversationlist/DJLConversationListViewController.mm
+++ b/Sources/UI/conversationlist/DJLConversationListViewController.mm
@@ -771,6 +771,7 @@ private:
 - (void) _reflectSelectionForCellView:(DJLConversationCellContentView *)cellView index:(NSInteger)idx selectedRows:(NSIndexSet *)selectedRows
 {
     [cellView setSelected:[selectedRows containsIndex:idx]];
+    [cellView setNextCellSelected:[selectedRows containsIndex:idx + 1]];
 }
 
 - (BOOL)tableView:(NSTableView *)aTableView shouldSelectRow:(NSInteger)rowIndex

--- a/Sources/UI/conversationlist/DJLConversationListViewController.mm
+++ b/Sources/UI/conversationlist/DJLConversationListViewController.mm
@@ -156,7 +156,8 @@ private:
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     _folderToReset = [[NSMutableSet alloc] init];
     _callback = new DJLConversationListViewControllerCallback(self);
-    _vibrancy = 1.0;
+    BOOL enableVibrancy = [[NSUserDefaults standardUserDefaults] boolForKey:@"DJLEnableVibrancy"];
+    _vibrancy = enableVibrancy ? 1.0 : 0.0;
     return self;
 }
 
@@ -445,6 +446,9 @@ private:
 
 - (void) setVibrancy:(CGFloat)vibrancy
 {
+    BOOL enableVibrancy = [[NSUserDefaults standardUserDefaults] boolForKey:@"DJLEnableVibrancy"];
+    vibrancy = enableVibrancy ? vibrancy : 0.0;
+    
     _vibrancy = vibrancy;
     [_tableView setBackgroundColor:[NSColor colorWithCalibratedWhite:1.0 alpha:1 - vibrancy]];
     NSRange range = [_tableView rowsInRect:[_tableView visibleRect]];

--- a/Sources/UI/mainwindow/DJLMainWindowController.h
+++ b/Sources/UI/mainwindow/DJLMainWindowController.h
@@ -19,6 +19,8 @@
 
 - (void) refresh;
 
+- (void) toggleEnableVibrancy;
+
 - (IBAction) toggleSidebar:(id)sender;
 - (IBAction) toggleDetails:(id)sender;
 - (IBAction) showLabelsPanel:(id)sender;

--- a/Sources/UI/mainwindow/DJLMainWindowController.mm
+++ b/Sources/UI/mainwindow/DJLMainWindowController.mm
@@ -651,6 +651,20 @@ public:
     }
 }
 
+- (void) toggleEnableVibrancy
+{
+    BOOL enableVibrancy = [[NSUserDefaults standardUserDefaults] boolForKey:@"DJLEnableVibrancy"];
+    
+    CGFloat targetVibrancy = enableVibrancy ? 1.0 : 0.0;
+    
+    if (![self _hasConversationPanel]) {
+        targetVibrancy = 0.0;
+    }
+    
+    [_toolbarView setVibrancy:targetVibrancy];
+    [_conversationListViewController setVibrancy:targetVibrancy];
+}
+
 - (void) toggleDetails:(id)sender
 {
     [self _setDetailsVisible:![self _hasConversationPanel] animated:YES];

--- a/Sources/UI/preferences/DJLPrefsGeneralViewController.m
+++ b/Sources/UI/preferences/DJLPrefsGeneralViewController.m
@@ -4,6 +4,7 @@
 #import "DJLPrefsGeneralViewController.h"
 
 #import "DJLURLHandler.h"
+#import "DJLAppDelegate.h"
 
 @interface DJLCheckboxButtonCell  : NSButtonCell
 
@@ -30,6 +31,7 @@
 @implementation DJLPrefsGeneralViewController {
     NSButton * _makeDefaultButton;
     NSButton * _playSoundButton;
+    NSButton * _enableVibrancyButton;
     NSButton * _zenNotificationsButton;
     NSTextField * _zenDescription;
 }
@@ -69,6 +71,16 @@
     [_playSoundButton setAction:@selector(_playSoundChanged:)];
     [[self view] addSubview:_playSoundButton];
 
+    _enableVibrancyButton = [[NSButton alloc] initWithFrame:NSZeroRect];
+    [_enableVibrancyButton setCell:[[DJLCheckboxButtonCell alloc] init]];
+    [_enableVibrancyButton setButtonType:NSSwitchButton];
+    [_enableVibrancyButton setTitle:@"Enable vibrancy in conversation list"];
+    [_enableVibrancyButton setFont:[NSFont systemFontOfSize:12]];
+    [_enableVibrancyButton sizeToFit];
+    [_enableVibrancyButton setTarget:self];
+    [_enableVibrancyButton setAction:@selector(_enableVibrancyChanged:)];
+    [[self view] addSubview:_enableVibrancyButton];
+    
     _zenNotificationsButton = [[NSButton alloc] initWithFrame:NSZeroRect];
     [_zenNotificationsButton setCell:[[DJLCheckboxButtonCell alloc] init]];
     [_zenNotificationsButton setButtonType:NSSwitchButton];
@@ -100,6 +112,8 @@
 {
     BOOL enabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"SoundEnabled"];
     [_playSoundButton setState:enabled ? NSOnState : NSOffState];
+    BOOL enableVibrancy = [[NSUserDefaults standardUserDefaults] boolForKey:@"DJLEnableVibrancy"];
+    [_enableVibrancyButton setState:enableVibrancy ? NSOnState : NSOffState];
     [_makeDefaultButton setState:[[DJLURLHandler sharedManager] isRegisteredAsDefault] ? NSOnState : NSOffState];
     enabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"ZenNotifications"];
     [_zenNotificationsButton setState:enabled ? NSOnState : NSOffState];
@@ -111,6 +125,9 @@
     width = [_makeDefaultButton frame].size.width;
     if ([_playSoundButton frame].size.width > width) {
         width = [_playSoundButton frame].size.width;
+    }
+    if ([_enableVibrancyButton frame].size.width > width) {
+        width = [_enableVibrancyButton frame].size.width;
     }
     if ([_zenNotificationsButton frame].size.width > width) {
         width = [_zenNotificationsButton frame].size.width;
@@ -127,24 +144,36 @@
     frame.origin.x = (int) x;
     frame.origin.y = [[self view] bounds].size.height - 70;
     [_playSoundButton setFrame:frame];
-    frame = [_zenNotificationsButton frame];
+    frame = [_enableVibrancyButton frame];
     frame.origin.x = (int) x;
     frame.origin.y = [[self view] bounds].size.height - 100;
+    [_enableVibrancyButton setFrame:frame];
+    frame = [_zenNotificationsButton frame];
+    frame.origin.x = (int) x;
+    frame.origin.y = [[self view] bounds].size.height - 130;
     [_zenNotificationsButton setFrame:frame];
     frame = [_zenDescription frame];
     frame.origin.x = (int) x + 10;
-    frame.origin.y = [[self view] bounds].size.height - 105 - frame.size.height;
+    frame.origin.y = [[self view] bounds].size.height - 135 - frame.size.height;
     [_zenDescription setFrame:frame];
 }
 
 - (CGFloat) height
 {
-    return 130 + [_zenDescription frame].size.height;
+    return 160 + [_zenDescription frame].size.height;
 }
 
 - (void) _playSoundChanged:(id)sender
 {
     [[NSUserDefaults standardUserDefaults] setBool:([_playSoundButton state] == NSOnState) forKey:@"SoundEnabled"];
+}
+
+- (void) _enableVibrancyChanged:(id)sender
+{
+    [[NSUserDefaults standardUserDefaults] setBool:([_enableVibrancyButton state] == NSOnState) forKey:@"DJLEnableVibrancy"];
+    
+    DJLAppDelegate *appDelegate = [NSApp delegate];
+    [appDelegate toggleEnableVibrancy];
 }
 
 - (void) _makeDefaultChanged:(id)sender

--- a/Sources/UI/toolbar/DJLToolbarView.m
+++ b/Sources/UI/toolbar/DJLToolbarView.m
@@ -40,13 +40,14 @@ static NSTimeInterval s_startTime = 0;
 {
     self = [super initWithFrame:frame];
 
-    _vibrancy = 1.0;
+    BOOL enableVibrancy = [[NSUserDefaults standardUserDefaults] boolForKey:@"DJLEnableVibrancy"];
+    _vibrancy = enableVibrancy ? 1.0 : 0.0;
 
     _validation = [[NSMutableDictionary alloc] init];
 
     _opaqueView = [[DJLColoredView alloc] initWithFrame:[self bounds]];
     [_opaqueView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
-    [_opaqueView setAlphaValue:0.0];
+    [_opaqueView setAlphaValue:enableVibrancy ? 0.0 : 1.0];
     [self addSubview:_opaqueView];
 
     NSRect separatorFrame = [self bounds];
@@ -248,6 +249,9 @@ static NSTimeInterval s_startTime = 0;
 
 - (void) setVibrancy:(CGFloat)vibrancy
 {
+    BOOL enableVibrancy = [[NSUserDefaults standardUserDefaults] boolForKey:@"DJLEnableVibrancy"];
+    vibrancy = enableVibrancy ? vibrancy : 0.0;
+    
     _vibrancy = vibrancy;
     [_opaqueView setAlphaValue:1.0 - _vibrancy];
     //[self setNeedsDisplay:YES];

--- a/Sources/main.m
+++ b/Sources/main.m
@@ -16,7 +16,8 @@ int main(int argc, const char * argv[])
                                        @"DJLConversationViewWidth": @600,
                                        @"DJLMainWindowHasFolderView": @NO,
                                        @"DJLMainWindowHasConversationView": @YES,
-                                       @"SoundEnabled": @YES};
+                                       @"SoundEnabled": @YES,
+                                       @"DJLEnableVibrancy": @YES};
     [[NSUserDefaults standardUserDefaults] registerDefaults:defaultSettings];
 
     DJLLogInit();


### PR DESCRIPTION
Do not draw separator above or below selection
highlight, mimicking iOS table view behavior.

This is a cosmetic change to make conversation list selection a little cleaner. The separator line is not drawn above or below the selection highlight.