### PR TITLE
Conditionally draw separator in conversation list

### DIFF
--- a/Sources/UI/conversationlist/DJLConversationCellContentView.h
+++ b/Sources/UI/conversationlist/DJLConversationCellContentView.h
@@ -10,6 +10,7 @@
 @property (nonatomic, weak) id <DJLConversationCellViewDelegate> delegate;
 @property (nonatomic, retain) NSDictionary * conversation;
 @property (nonatomic, assign, getter=isSelected) BOOL selected;
+@property (nonatomic, assign, getter=isNextCellSelected) BOOL nextCellSelected;
 @property (nonatomic, assign) CGFloat vibrancy;
 @property (nonatomic, retain) NSString * folderPath;
 

--- a/Sources/UI/conversationlist/DJLConversationCellContentView.m
+++ b/Sources/UI/conversationlist/DJLConversationCellContentView.m
@@ -11,6 +11,7 @@
     NSVisualEffectView * _effectView;
     DJLColoredView * _opaqueView;
     BOOL _selected;
+    BOOL _nextCellSelected;
     CGFloat _vibrancy;
     NSString * _folderPath;
 }
@@ -78,6 +79,20 @@
 - (BOOL) isSelected
 {
     return _selected;
+}
+
+- (void) setNextCellSelected:(BOOL)nextCellSelected
+{
+    if (_nextCellSelected == nextCellSelected) {
+        return;
+    }
+    _nextCellSelected = nextCellSelected;
+    [_mainView setNextCellSelected:_nextCellSelected];
+}
+
+- (BOOL) isNextCellSelected
+{
+    return _nextCellSelected;
 }
 
 - (CGFloat) vibrancy

--- a/Sources/UI/conversationlist/DJLConversationCellView.h
+++ b/Sources/UI/conversationlist/DJLConversationCellView.h
@@ -12,6 +12,7 @@
 @property (nonatomic, weak) id <DJLConversationCellViewDelegate> delegate;
 @property (nonatomic, retain) NSDictionary * conversation;
 @property (nonatomic, assign, getter=isSelected) BOOL selected;
+@property (nonatomic, assign, getter=isNextCellSelected) BOOL nextCellSelected;
 @property (nonatomic, assign) CGFloat vibrancy;
 @property (nonatomic, retain) NSString * folderPath;
 

--- a/Sources/UI/conversationlist/DJLConversationCellView.mm
+++ b/Sources/UI/conversationlist/DJLConversationCellView.mm
@@ -233,6 +233,7 @@ using namespace mailcore;
     __weak id <DJLConversationCellViewDelegate> _delegate;
     FBKVOController * _kvoController;
     BOOL _selected;
+    BOOL _nextCellSelected;
     CGFloat _vibrancy;
 }
 
@@ -573,11 +574,14 @@ using namespace mailcore;
         [str drawAtPoint:NSMakePoint(0, bounds.size.height - 30) withAttributes:attr];
     }
 
-    path = [[NSBezierPath alloc] init];
-    [path moveToPoint:NSMakePoint(60, 0)];
-    [path lineToPoint:NSMakePoint(bounds.size.width, 0)];
-    [[NSColor colorWithCalibratedWhite:0.0 alpha:0.15] setStroke];
-    [path stroke];
+    // Separator line. Do not draw it above or below selection highlight.
+    if (!_nextCellSelected && !_selected) {
+        path = [[NSBezierPath alloc] init];
+        [path moveToPoint:NSMakePoint(60, 0)];
+        [path lineToPoint:NSMakePoint(bounds.size.width, 0)];
+        [[NSColor colorWithCalibratedWhite:0.0 alpha:0.15] setStroke];
+        [path stroke];
+    }
 }
 
 - (void) setConversation:(NSDictionary *)conversation
@@ -617,6 +621,20 @@ using namespace mailcore;
     }
     _selected = selected;
     [_snippetView setSelected:_selected];
+    [self setNeedsDisplay:YES];
+}
+
+- (BOOL) isNextCellSelected
+{
+    return _nextCellSelected;
+}
+
+- (void) setNextCellSelected:(BOOL)nextCellSelected
+{
+    if (_nextCellSelected == nextCellSelected) {
+        return;
+    }
+    _nextCellSelected = nextCellSelected;
     [self setNeedsDisplay:YES];
 }
 

--- a/Sources/UI/conversationlist/DJLConversationListViewController.mm
+++ b/Sources/UI/conversationlist/DJLConversationListViewController.mm
@@ -771,6 +771,7 @@ private:
 - (void) _reflectSelectionForCellView:(DJLConversationCellContentView *)cellView index:(NSInteger)idx selectedRows:(NSIndexSet *)selectedRows
 {
     [cellView setSelected:[selectedRows containsIndex:idx]];
+    [cellView setNextCellSelected:[selectedRows containsIndex:idx + 1]];
 }
 
 - (BOOL)tableView:(NSTableView *)aTableView shouldSelectRow:(NSInteger)rowIndex


### PR DESCRIPTION
Do not draw separator above or below selection
highlight, mimicking iOS table view behavior.