### PR TITLE
Truncate attachment filenames in the middle

### DIFF
--- a/Sources/UI/conversationlist/DJLConversationCellView.mm
+++ b/Sources/UI/conversationlist/DJLConversationCellView.mm
@@ -183,10 +183,14 @@ using namespace mailcore;
 
         rect.origin.x = x + 5;
         rect.origin.y = 50 + 12;
-        rect.size.width = size.width;
+        rect.size.width = self.bounds.size.width - statusMargin - rect.origin.x;
         rect.size.height = size.height;
 
-        [attachmentString drawWithRect:rect options:0 attributes:labelAttr];
+        NSMutableParagraphStyle * paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+        [paragraphStyle setLineBreakMode:NSLineBreakByTruncatingMiddle];
+        NSMutableDictionary * attr = [labelAttr mutableCopy];
+        attr[NSParagraphStyleAttributeName] = paragraphStyle;
+        [attachmentString drawWithRect:rect options:0 attributes:attr];
 
         x += (int) size.width + 10;
     }


### PR DESCRIPTION
By truncating in the middle, it is possible to
still see the file extension for long filenames.

Without truncation:
<img width="259" alt="notrunc" src="https://user-images.githubusercontent.com/118104/35066056-1e6e855c-fb84-11e7-84e6-6fdfbf567f1f.png">

With truncation:
<img width="259" alt="trunc" src="https://user-images.githubusercontent.com/118104/35066060-228db1d0-fb84-11e7-86b1-8ebe5e7e7977.png">
