### PR TITLE
Select right-clicked conversation if it is not already in selection

### DIFF
--- a/Sources/UI/conversationlist/DJLConversationListViewController.mm
+++ b/Sources/UI/conversationlist/DJLConversationListViewController.mm
@@ -918,7 +918,7 @@ private:
 - (NSMenu *) djl_tableView:(NSTableView *)tableView menuForEvent:(NSEvent *)event row:(NSInteger)row
 {
     // Select right-clicked row if it isn't already in the selection.
-    if ([[_tableView selectedRowIndexes] containsIndex:row] == NO) {
+    if (![[_tableView selectedRowIndexes] containsIndex:row]) {
         if (row != -1) {
             [_tableView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
         }

--- a/Sources/UI/conversationlist/DJLConversationListViewController.mm
+++ b/Sources/UI/conversationlist/DJLConversationListViewController.mm
@@ -917,7 +917,8 @@ private:
 
 - (NSMenu *) djl_tableView:(NSTableView *)tableView menuForEvent:(NSEvent *)event row:(NSInteger)row
 {
-    if ([[_tableView selectedRowIndexes] count] == 0) {
+    // Select right-clicked row if it isn't already in the selection.
+    if ([[_tableView selectedRowIndexes] containsIndex:row] == NO) {
         if (row != -1) {
             [_tableView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
         }


### PR DESCRIPTION
If a user right-clicks a row in the conversation list (to bring up the context menu), that row is selected so that the context menu actions apply to it. The selection is not altered if the user right-clicks a row that is already in the selection.