### PR TITLE
Fix unread status indicator position

### DIFF
--- a/Sources/UI/conversationlist/DJLConversationStatusView.m
+++ b/Sources/UI/conversationlist/DJLConversationStatusView.m
@@ -119,8 +119,8 @@ static BOOL s_interactionEnabled = NO;
     NSNumber * nbStarred = [_conversation objectForKey:@"starred"];
     
     if (![self isStar]) {
+        NSRect rect = NSMakeRect(7, 9, 10, 10);
         if ([nbUnread boolValue]) {
-            NSRect rect = NSMakeRect(8, 8, 9, 9);
             NSColor * color = nil;
             if (_tracking) {
                 if (_clickingInside) {
@@ -149,7 +149,6 @@ static BOOL s_interactionEnabled = NO;
             }
         }
         else {
-            NSRect rect = NSMakeRect(8, 9, 9, 9);
             NSColor * color = nil;
             if (_clickingInside) {
                 color = [NSColor colorWithCalibratedRed:0.6 green:0.6 blue:1.0 alpha:1.0];


### PR DESCRIPTION
The unread status indicator would move 1 pixel when you clicked it. It was also slightly off-center from the star indicator. This commit addresses both issues.